### PR TITLE
Fix: 로그아웃 처리 및 메인페이지의 페이지 번호 수정

### DIFF
--- a/src/main/webapp/WEB-INF/views/admin/adminTopInc.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/adminTopInc.jsp
@@ -1,7 +1,12 @@
-<%@page import="java.util.Date" %>
+<%@ page import="com.needle.FsoFso.common.util.AttributeContainer" %>
+<%@ page import="com.needle.FsoFso.member.service.Member" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
          pageEncoding="UTF-8" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%
+    boolean isLoggedIn = AttributeContainer.hasSessionAttributeOf(request, "member");
+    final Member member = (Member) AttributeContainer.sessionAttributeFrom(request, "member");
+%>
 <header>
     <div class="header-container">
         <div class="header-wrapper">
@@ -30,12 +35,19 @@
                     <span class="css-18nk785">회원관리</span>
                 </a>
             </div>
-
             <div class="header-items">
+
                 <div class="header-links">
-                    <a class="header-link-item" href="/logout.do">
+                    <% if (isLoggedIn) { %>
+                    <a class="header-link-item"
+                       href="<%=request.getContextPath()%>/logout.do?id=<%=member.getId()%>">
                         로그아웃
                     </a>
+                    <% } else { %>
+                    <a class="header-link-item" href="<%=request.getContextPath()%>/login.do">
+                        로그인
+                    </a>
+                    <% } %>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/WEB-INF/views/layouts-tiles.jsp
+++ b/src/main/webapp/WEB-INF/views/layouts-tiles.jsp
@@ -1,28 +1,26 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
-    pageEncoding="UTF-8"%>
-<%@ taglib prefix="tiles" uri="http://tiles.apache.org/tags-tiles"%>    
+         pageEncoding="UTF-8" %>
+<%@ taglib prefix="tiles" uri="http://tiles.apache.org/tags-tiles" %>
 <!DOCTYPE html>
 <html>
 <head>
-<meta charset="UTF-8">
-<title>5so4so</title>
-<tiles:insertAttribute name="header"/>		<!-- link 파일 (bootstrap, jquery) -->
+    <meta charset="UTF-8">
+    <title>5so4so</title>
+    <tiles:insertAttribute name="header"/>        <!-- link 파일 (bootstrap, jquery) -->
 </head>
 <body>
 <div id="body_wrap">
-	<div id="main_wrap">
-		<tiles:insertAttribute name="top_inc"/>
-	</div>
-	<div id="middle_wrap">
-		<div id="content_wrap">
-			<tiles:insertAttribute name="main"/>
-		</div>
-		
-		<div id="footer_wrap">
-			<tiles:insertAttribute name="bottom_inc"/>
-		</div>
-	</div>
-	
+    <div id="main_wrap">
+        <tiles:insertAttribute name="top_inc"/>
+    </div>
+    <div id="middle_wrap">
+        <div id="content_wrap">
+            <tiles:insertAttribute name="main"/>
+        </div>
+    </div>
+    <div id="footer_wrap">
+        <tiles:insertAttribute name="bottom_inc"/>
+    </div>
 </div>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/main.jsp
+++ b/src/main/webapp/WEB-INF/views/main.jsp
@@ -2,184 +2,180 @@
          pageEncoding="UTF-8" %>
 <%@page import="java.util.List" %>
 <%@page import="com.needle.FsoFso.product.dto.ProductDto" %>
+<%@ page import="java.util.Optional" %>
 <%
     List<ProductDto> productList = (List<ProductDto>) request.getAttribute("productList");
 %>
 <!DOCTYPE html>
 <html>
 <head>
-<meta charset="UTF-8">
-<title>main</title>
-<link rel="stylesheet" href="<%=request.getContextPath()%>/css/product/main.css">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1" />
-<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <meta charset="UTF-8">
+    <title>main</title>
+    <link rel="stylesheet" href="<%=request.getContextPath()%>/css/product/main.css">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1"/>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 
-<!-- GSAP & ScrollToPlugin -->
-<script
-		src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"
-		integrity="sha512-H6cPm97FAsgIKmlBA4s774vqoN24V5gSQL4yBTDOY2su2DeXZVhQPxFK4P6GPdnZqM9fg1G3cMv5wD7e6cFLZQ=="
-		crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-<script
-		src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollToPlugin.min.js"
-		integrity="sha512-agNfXmEo6F+qcj3WGryaRvl9X9wLMQORbTt5ACS9YVqzKDMzhRxY+xjgO45HCLm61OwHWR1Oblp4QSw/SGh9SA=="
-		crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-<!-- Link Swiper's CSS -->
-<link rel="stylesheet"
-	  href="https://unpkg.com/swiper/swiper-bundle.min.css" />
-<!-- Swiper JS -->
-<script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    <!-- GSAP & ScrollToPlugin -->
+    <script
+            src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"
+            integrity="sha512-H6cPm97FAsgIKmlBA4s774vqoN24V5gSQL4yBTDOY2su2DeXZVhQPxFK4P6GPdnZqM9fg1G3cMv5wD7e6cFLZQ=="
+            crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script
+            src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollToPlugin.min.js"
+            integrity="sha512-agNfXmEo6F+qcj3WGryaRvl9X9wLMQORbTt5ACS9YVqzKDMzhRxY+xjgO45HCLm61OwHWR1Oblp4QSw/SGh9SA=="
+            crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <!-- Link Swiper's CSS -->
+    <link rel="stylesheet"
+          href="https://unpkg.com/swiper/swiper-bundle.min.css"/>
+    <!-- Swiper JS -->
+    <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
 </head>
 <body>
 <div class="swiper mySwiper">
-	<div class="swiper-wrapper">
-		<div class="swiper-slide">
-			<img alt=""
-				 src="<%=request.getContextPath()%>/images/product/slide1.png">
-		</div>
-		<div class="swiper-slide">
-			<img alt=""
-				 src="<%=request.getContextPath()%>/images/product/slide2.png">
-		</div>
-		<div class="swiper-slide">
-			<img alt=""
-				 src="<%=request.getContextPath()%>/images/product/slide3.png">
-		</div>
-		<div class="swiper-slide">
-			<img alt=""
-				 src="<%=request.getContextPath()%>/images/product/slide4.png">
-		</div>
-		<div class="swiper-slide">
-			<img alt=""
-				 src="<%=request.getContextPath()%>/images/product/slide5.png">
-		</div>
-	</div>
-	<div class="swiper-pagination"></div>
+    <div class="swiper-wrapper">
+        <div class="swiper-slide">
+            <img alt=""
+                 src="<%=request.getContextPath()%>/images/product/slide1.png">
+        </div>
+        <div class="swiper-slide">
+            <img alt=""
+                 src="<%=request.getContextPath()%>/images/product/slide2.png">
+        </div>
+        <div class="swiper-slide">
+            <img alt=""
+                 src="<%=request.getContextPath()%>/images/product/slide3.png">
+        </div>
+        <div class="swiper-slide">
+            <img alt=""
+                 src="<%=request.getContextPath()%>/images/product/slide4.png">
+        </div>
+        <div class="swiper-slide">
+            <img alt=""
+                 src="<%=request.getContextPath()%>/images/product/slide5.png">
+        </div>
+    </div>
+    <div class="swiper-pagination"></div>
 </div>
 <div class="productList">
-	<div class="productListInner">
-		<%
-			for (int i = 0; i < productList.size(); i++) {
+    <div class="productListInner">
+        <div class="productListItems">
+            <%
+                for (ProductDto product : productList) {
+            %>
+            <div class="productWrapper">
+                <div class="productImage">
+                    <a href="productDetail.do?id=<%=product.getId()%>">
+                        <img alt="<%=product.getName()%>" src="<%=product.getthumbnailUrl()%>"
+                             width="269" height="269">
+                    </a>
+                </div>
+                <div class="productContent">
+                    <div class="productTitle">
+                        <a href="productDetail.do?id=<%=product.getId()%>"
+                           style="text-decoration: none"> <span class="productName"><%=
+                        product.getName()%></span>
+                        </a>
+                    </div>
+                    <div class="productPrice">
+                        <span class="price"><%=product.getPrice()%>원</span>
+                    </div>
+                </div>
+            </div>
+            <%
+                }
+            %>
+        </div>
+        <div class="productListPageNum">
+            <%
+                Optional<Integer> startPageNumber = Optional.ofNullable(
+                        (Integer) request.getAttribute("pageNumber"));
 
-				ProductDto product = productList.get(i);
-		%>
-		<div class="productWrapper">
-			<div class="productImage">
-				<a href="productDetail.do?id=<%=product.getId()%>"> <img alt=""
-																	 src="<%=product.getthumbnailUrl()%>" width="269" height="269">
-				</a>
-			</div>
-			<div class="productContent">
-				<div class="productTitle">
-					<a href="productDetail.do?id=<%=product.getId()%>"
-					   style="text-decoration: none"> <span class="productName"><%=product.getName()%></span>
-					</a>
-				</div>
-				<div class="productPrice">
-					<span class="price"><%=product.getPrice()%>원</span>
-				</div>
+                int pageNumber = 0;
+                if (startPageNumber.isPresent()) {
+                    pageNumber = startPageNumber.get();
+                }
 
-			</div>
+                int totalCount = (int) request.getAttribute("totalCount");
 
-		</div>
-		<%
-			}
-		%>
-
-		<div class="pageNum">
-			<%
-				String startPageNumber = (String) request.getAttribute("pageNumber");
-
-				int pageNumber = 0;
-				if (startPageNumber != null && !startPageNumber.equals("")) {
-					pageNumber = Integer.parseInt(startPageNumber);
-				}
-
-				int totalCount = (int) request.getAttribute("totalCount");
-
-				// 페이지의 수
-				int productPerPage = totalCount / 12;
-				if ((totalCount % 12) > 0) {
-					productPerPage = productPerPage + 1;
-				}
-			%>
-			<%
-				for (int i = 0; i < productPerPage; i++) {
-					if (pageNumber == i) {
-			%>
-			<span style="font-size: 15pt; color: #35c5f0; font-weight: bold;">
+                int productPerPage = totalCount / 12;
+                if ((totalCount % 12) > 0) {
+                    productPerPage = productPerPage + 1;
+                }
+            %>
+            <%
+                for (int i = 0; i < productPerPage; i++) {
+                    if (pageNumber == i) {
+            %>
+            <span style="font-size: 15pt; color: #35c5f0; font-weight: bold;">
 				<%=i + 1%>
 			</span>
-			<%
-			} else {
-			%>
-			<a href="#none" title="<%=i + 1%>페이지" onclick="goPage(<%=i%>)"
-			   style="font-size: 15pt; color: #000; font-weight: bold; text-decoration: none;">
-				<%=i + 1%>
-			</a>
-			<%
-					}
-				}
-			%>
-		</div>
-	</div>
+            <%
+            } else {
+            %>
+            <a href="#" title="<%=i + 1%>페이지" onclick="goPage(<%=i%>)"
+               style="font-size: 15pt; color: #000; font-weight: bold; text-decoration: none;">
+                <%=i + 1%>
+            </a>
+            <%
+                    }
+                }
+            %>
+        </div>
+    </div>
 </div>
 
 <div id="to-top">
-	<div class="material-icons">arrow_upward</div>
+    <div class="material-icons">arrow_upward</div>
 </div>
 
 <script type="text/javascript">
-	<!-- Initialize Swiper -->
-	const swiper = new Swiper(".mySwiper", {
-		pagination: {
-			el: ".swiper-pagination",
-		},
-		autoplay: {
-			delay: 3000,
-		},
-	});
+  <!-- Initialize Swiper -->
+  const swiper = new Swiper(".mySwiper", {
+    pagination: {
+      el: ".swiper-pagination",
+    },
+    autoplay: {
+      delay: 3000,
+    },
+  });
 
-	function goPage( pageNumber ) {
-		location.href = "productList.do?pageNumber=" + pageNumber;
-	}
+  function goPage(pageNumber) {
+    location.href = "productList.do?pageNumber=" + pageNumber;
+  }
 
+  const toTopEl = document.querySelector('#to-top');
+  window.addEventListener('scroll', function () {
+    if (window.scrollY > 300) {
+      // 배지 숨기기
+      // gsap.to(요소, 지속시간, 옵션)
+      gsap.to(toTopEl, .2, {
+        x: 0
+      });
+    } else {
+      // 버튼 숨기기!
+      gsap.to(toTopEl, .2, {
+        x: 100
+      });
+    }
+  }, 300);
 
+  toTopEl.addEventListener('click', function () {
+    gsap.to(window, .7, {
+      scrollTo: 0
+    });
+  });
 
-	const toTopEl = document.querySelector('#to-top');
-
-	window.addEventListener('scroll', function(){
-		if (window.scrollY > 300){
-			// 배지 숨기기
-			// gsap.to(요소, 지속시간, 옵션)
-			gsap.to(toTopEl, .2, {
-				x: 0
-			});
-		}
-		else{
-			// 버튼 숨기기!
-			gsap.to(toTopEl, .2, {
-				x: 100
-			});
-		}
-	}, 300);
-
-	toTopEl.addEventListener('click', function() {
-		gsap.to(window, .7, {
-			scrollTo: 0
-		});
-	});
-
-
-	const spyEls = document.querySelectorAll('section.scroll-spy');
-	spyEls.forEach(function(spyEl) {
-		new ScrollMagic
-		.Scene({
-			triggerElement: spyEl, // 보여짐 여부를 감시할 요소를 지정
-			triggerHook: .8
-		})
-		.setClassToggle(spyEl, 'show')
-		.addTo(new ScrollMagic.Controller());
-	});
+  const spyEls = document.querySelectorAll('section.scroll-spy');
+  spyEls.forEach(function (spyEl) {
+    new ScrollMagic
+    .Scene({
+      triggerElement: spyEl, // 보여짐 여부를 감시할 요소를 지정
+      triggerHook: .8
+    })
+    .setClassToggle(spyEl, 'show')
+    .addTo(new ScrollMagic.Controller());
+  });
 </script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/search/searchList.jsp
+++ b/src/main/webapp/WEB-INF/views/search/searchList.jsp
@@ -49,7 +49,7 @@
 %>
 </div>
 <br>
-<div class="pageNum">
+<div class="productListPageNum">
 <%
 	for (int i = 0; i < searchPage; i++){
 		if (pageNumber == i) {

--- a/src/main/webapp/css/product/main.css
+++ b/src/main/webapp/css/product/main.css
@@ -56,10 +56,16 @@
 	border-radius: 4px; 
 }
 
-.pageNum {
-	position: absolute;
-	left: 49%;
-	bottom: -70%;
+.productListInner {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+
+.productListPageNum {
+
 }
 
 


### PR DESCRIPTION
## resolve #31 #33
### 설명
- 관리자 페이지의 헤더에 로그인 검증 로직이 추가되지 않아 제대로 로그아웃되지 않던 문제를 처리했습니다.
- 메인 페이지의 페이지 번호가 정상적으로 출력되도록 수정했습니다.
    <img width="837" alt="스크린샷 2022-07-21 오전 9 38 11" src="https://user-images.githubusercontent.com/52682603/180105514-2eff234a-ca7a-4e23-9e24-4ac062d5efa3.png">
- Footer 위치를 메인과 같은 수준에서 분리했습니다.